### PR TITLE
Updated the URL for the hosted version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 ## Getting started
 
-The easiest way to start using Prefetchalyzer is by using the hosted version available [here](https://gtech-professional-services.github.io/prefetchalyzer/).
+The easiest way to start using Prefetchalyzer is by using the hosted version available [here](https://google-marketing-solutions.github.io/prefetchalyzer/).
 
 ## Project setup
 The project was generated with vue-cli.


### PR DESCRIPTION
The organization changed its name, so all of the github.io links changed as well. The link to the hosted version needed to be updated to reflect that.